### PR TITLE
Fix "readlink" bug with relative softlinks

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -33,8 +33,8 @@ endif
 OUT_DOCKER ?= tracee
 DOCKER_BUILDER ?= tracee-builder
 # DOCKER_BUILDER_KERN_SRC(/BLD) is where the docker builder looks for kernel headers
-DOCKER_BUILDER_KERN_BLD ?= $(if $(shell readlink $(KERN_BLD_PATH)),$(shell readlink $(KERN_BLD_PATH)),$(KERN_BLD_PATH))
-DOCKER_BUILDER_KERN_SRC ?= $(if $(shell readlink $(KERN_SRC_PATH)),$(shell readlink $(KERN_SRC_PATH)),$(KERN_SRC_PATH))
+DOCKER_BUILDER_KERN_BLD ?= $(if $(shell readlink -f $(KERN_BLD_PATH)),$(shell readlink -f $(KERN_BLD_PATH)),$(KERN_BLD_PATH))
+DOCKER_BUILDER_KERN_SRC ?= $(if $(shell readlink -f $(KERN_SRC_PATH)),$(shell readlink -f $(KERN_SRC_PATH)),$(KERN_SRC_PATH))
 # DOCKER_BUILDER_KERN_SRC_MNT is the kernel headers directory to mount into the docker builder container. DOCKER_BUILDER_KERN_SRC should usually be a descendent of this path.
 DOCKER_BUILDER_KERN_SRC_MNT ?= $(dir $(DOCKER_BUILDER_KERN_SRC))
 LINUX_VERSION_CODE := $(shell uname -r | awk '{split($$0,a,"."); split(a[3], b, "-"); print lshift(a[1], 16) + lshift(a[2],8) + b[1];}')


### PR DESCRIPTION
Modify the readlink in the Makefile file so that it works properly with relative softlinks in CentOS.


My test procedure on CentOS 7 is as follows：

```bash
$ cd tracee-ebpf && make build DOCKER=1 --just-print
....
Step 3/3 : WORKDIR /tracee
 ---> Using cache
 ---> 5e8a792b8117
Successfully built 5e8a792b8117
Successfully tagged tracee-builder:latest
docker run --rm -v /root/tracee/tracee-ebpf:./ -v /root/tracee/tracee-ebpf:/tracee/tracee-ebpf -w /tracee/tracee-ebpf --entrypoint make tracee-builder KERN_BLD_PATH=/usr/src/kernels/5.4.132-1.el7.elrepo.x86_64 KERN_SRC_PATH=build dist/tracee-ebpf VERSION=v0.6.1-1-gce65764
docker: Error response from daemon: invalid volume specification: '/root/tracee/tracee-ebpf:./': invalid mount config for type "bind": invalid mount path: './' mount path must be absolute.
See 'docker run --help'.
make: *** [dist/tracee-ebpf] Error 125
```



The difference is as follows：

CentOS

```bash
# ls -hl /lib/modules/5.4.132-1.el7.elrepo.x86_64/source
lrwxrwxrwx 1 root root 5 Jul 22 15:12 /lib/modules/5.4.132-1.el7.elrepo.x86_64/source -> build
```

Ubuntu

```bash
# ls -hl /lib/modules/5.4.0-42-generic/build
lrwxrwxrwx 1 root root 39 Jul 10  2020 /lib/modules/5.4.0-42-generic/build -> /usr/src/linux-headers-5.4.0-42-generic
```